### PR TITLE
Change license to MIT in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "models"
   ],
   "author": "Ian DeRanieri",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Emkaytoo/craft-json-snippets/issues"
   },


### PR DESCRIPTION
It was set to ISC in your package.json, but judging by the LICENSE file you obviously want MIT.